### PR TITLE
Allow to choose the type of the output file

### DIFF
--- a/lib/aasm_diagram/diagram.rb
+++ b/lib/aasm_diagram/diagram.rb
@@ -3,8 +3,9 @@ module AASMDiagram
   # Save a diagram of a single AASM state machine to an image
   #
   class Diagram
-    def initialize(aasm_instance, filename)
+    def initialize(aasm_instance, filename, type=:png)
       @aasm_instance = aasm_instance
+      @type = type
       draw
       save(filename)
     end
@@ -33,7 +34,7 @@ module AASMDiagram
     end
 
     def save(filename)
-      @graphviz.output(png: filename)
+      @graphviz.output(@type => filename)
     end
 
     private


### PR DESCRIPTION
This PR allows to choose the type of output expected from GraphViz.
It defaults to PNG to be consistent with the previous behaviour.

Expected usage:

 ```ruby
  # generate a diagram in "dot" format
  my_sm = some_object.aasm(:state)
  AASMDiagram::Diagram.new(my_sm, "somefile.dot", :dot)
 ```