### PR TITLE
Fix #1

### DIFF
--- a/lib/aasm_diagram/diagram.rb
+++ b/lib/aasm_diagram/diagram.rb
@@ -28,7 +28,7 @@ module AASMDiagram
           from = @graphviz.get_node(transition.from.to_s)
           to = @graphviz.get_node(transition.to.to_s)
           label = event.name.to_s
-          @graphviz.add_edges(from, to, label: label)
+          @graphviz.add_edges(from, to, label: label)  unless from.nil?
         end
       end
     end

--- a/lib/aasm_diagram/version.rb
+++ b/lib/aasm_diagram/version.rb
@@ -1,3 +1,3 @@
 module AASMDiagram
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.1.1'.freeze
 end


### PR DESCRIPTION
`aasm` allows for `from` to not be set for a transition - meaning any state can
transition to the `to` state. However `graphviz#add_edges` requires `from` to not be nil.

This PR checks for `from.nil?` before calling `graphviz#add_edges`