### PR TITLE
Permit AASM version 5.x

### DIFF
--- a/aasm-diagram.gemspec
+++ b/aasm-diagram.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'aasm', '~> 4.12'
+  spec.add_runtime_dependency 'aasm', ['>= 4.12', '~> 5.0']
   spec.add_runtime_dependency 'ruby-graphviz', '~> 1.2'
 
   spec.add_development_dependency 'bundler', '~> 1.14'


### PR DESCRIPTION
### Why
As of July 2018, AASM is in version 5, see [Releases](https://github.com/aasm/aasm/releases).

### What
Update gemspec runtime dependency to allow 4.x both 5.x version of AASM.

I've tested this with version 5 and things are still working well.