### PR TITLE
Add `generate` rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,59 @@ Generates the following diagram:
 
 ## Installation
 
-* Install Graphviz ([see the rails-erd guide for more details](https://voormedia.github.io/rails-erd/install.html)). If you use Homebrew try `brew install graphviz`.
-* Add `gem 'aasm-diagram', require: false, group: :development` to your `Gemfile` and run `bundle`.
+- Install Graphviz ([see the rails-erd guide for more details](https://voormedia.github.io/rails-erd/install.html)). If you use Homebrew try `brew install graphviz`.
+- Add `gem 'aasm-diagram', require: false, group: :development` to your `Gemfile` and run `bundle`.
+
+## Integration
+
+The gem exposes the `generate` Rake task, that can be used to generate the diagrams of state machines into
+PNG images. The `generate` task accepts two parameters:
+
+- the name of the model, in underscored format, will be CamelCased by the task
+- the name of the state machine, for models with multiple AASMs; this argument is optional
+
+The task will output the PNG image by default to the `/tmp` folder; but can be configured via the
+`AASM_DIAGRAM_OUTPUT_DIR` environment variable to write the files to another folder.
+
+The filenames are generated based on the parameters as follows `model_name-state_machine_name.png`.
+If no state machine name is provided, the task will use `default` for the file name.
+
+```sh
+# for the Order model and the :dropoff state machine
+rake aasm-diagram:generate[order,dropoff] # -> tmp/order-dropoff.png
+
+# for the Invoice model and the "default" state machine
+rake aasm-diagram:generate[invoice] # -> tmp/invoice-default.png
+
+# with custom output directory
+AASM_DIAGRAM_OUTPUT_DIR=docs rake aasm-diagram:generate[invoice] # -> docs/invoice-default.png
+```
+
+### Rails
+
+Once installed, the gem automatically integrates with Rails via Railties and exposes the task automatically.
+
+`rails aasm-diagram:generate[my_model,my_state_machine]`
+
+If the model contains only one state machine, or you just want to generate for the "default" one
+you can skip the state machine name parameter.
+
+`rails assm-diagram:generate[my_model]`
+
+### Plain Ruby
+
+For plain Ruby projects the gem includes a Rakefile that can be loaded in your project's Rakefile,
+using source code along the lines of:
+
+```ruby
+# in Rakefile
+
+require 'aasm-diagram'
+
+spec = Gem::Specification.find_by_name 'aasm-diagram'
+rakefile = "#{spec.gem_dir}/lib/aasm_diagram/Rakefile"
+load rakefile
+```
 
 ## More Examples
 

--- a/lib/aasm-diagram.rb
+++ b/lib/aasm-diagram.rb
@@ -3,3 +3,5 @@ require 'graphviz'
 
 require 'aasm_diagram/version'
 require 'aasm_diagram/diagram'
+
+require 'aasm_diagram/railtie' if defined?(Rails)

--- a/lib/aasm_diagram/Rakefile
+++ b/lib/aasm_diagram/Rakefile
@@ -1,0 +1,4 @@
+require 'aasm-diagram'
+
+path = File.expand_path(__dir__)
+Dir.glob("#{path}/tasks/*.rake").each { |f| import f }

--- a/lib/aasm_diagram/railtie.rb
+++ b/lib/aasm_diagram/railtie.rb
@@ -1,0 +1,13 @@
+require 'aasm-diagram'
+require 'rails'
+
+module AASMDiagram
+  class Railtie < Rails::Railtie
+    railtie_name :aasm_diagram
+
+    rake_tasks do
+      path = File.expand_path(__dir__)
+      Dir.glob("#{path}/tasks/*.rake").each { |f| load f }
+    end
+  end
+end

--- a/lib/aasm_diagram/tasks/generate.rake
+++ b/lib/aasm_diagram/tasks/generate.rake
@@ -1,0 +1,20 @@
+namespace :'aasm-diagram' do
+  desc 'Generate AASM diagram for the given model and (optionally) state machine'
+  task :generate, [:model, :smn] => :environment do |_task, args|
+    puts 'Missing `model` argument.' unless args[:model].present?
+    model_klass = args[:model].camelize.safe_constantize
+    puts 'Invalid `model` argument.' unless model_klass
+
+    smn = args[:smn]&.to_sym
+
+    model_instance = model_klass.new
+
+    output_dir = ENV.fetch('AASM_DIAGRAM_OUTPUT_DIR') { './tmp' }
+    output = File.join([output_dir, "#{args[:model]}-#{args[:smn] || 'default'}.png"])
+
+    AASMDiagram::Diagram.new(
+      smn && model_instance.aasm(smn) || model_instance.aasm,
+      output
+    )
+  end
+end


### PR DESCRIPTION
Add support for rake tasks, integration with both Rails or plain Ruby
Add implementation and documentation for the `generate` rake task

Addresses #9 