### PR TITLE
fix: missing subclass transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ class Job
   end
 end
 
-job = Job.new
-
-AASMDiagram::Diagram.new(job.aasm, 'docs/job.png')
+AASMDiagram::Diagram.new(Job.aasm, 'docs/job.png')
 ```
 
 Generates the following diagram:
@@ -130,8 +128,7 @@ class Cleaner
   end
 end
 
-cleaner = Cleaner.new
-AASMDiagram::Diagram.new(job.aasm, '../docs/guard-cleaner.png')
+AASMDiagram::Diagram.new(Cleaner.aasm, '../docs/guard-cleaner.png')
 ```
 
 ![Diagram of Cleaner state machine](docs/guard-cleaner.png)
@@ -170,9 +167,8 @@ class SimpleMultipleExample
   end
 end
 
-simple = SimpleMultipleExample.new
-AASMDiagram::Diagram.new(simple.aasm(:move), 'docs/multiple-state-machines-1.png')
-AASMDiagram::Diagram.new(simple.aasm(:work), 'docs/multiple-state-machines-2.png')
+AASMDiagram::Diagram.new(SimpleMultipleExample.aasm(:move), 'docs/multiple-state-machines-1.png')
+AASMDiagram::Diagram.new(SimpleMultipleExample.aasm(:work), 'docs/multiple-state-machines-2.png')
 ```
 
 Generates two images:

--- a/aasm-diagram.gemspec
+++ b/aasm-diagram.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'aasm', ['>= 4.12', '~> 5.0']
   spec.add_runtime_dependency 'ruby-graphviz', '~> 1.2'
 
-  spec.add_development_dependency 'bundler', '~> 2.1.4'
+  spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/aasm-diagram.gemspec
+++ b/aasm-diagram.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'aasm', ['>= 4.12', '~> 5.0']
   spec.add_runtime_dependency 'ruby-graphviz', '~> 1.2'
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler', '~> 2.1.4'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/lib/aasm_diagram/diagram.rb
+++ b/lib/aasm_diagram/diagram.rb
@@ -48,7 +48,7 @@ module AASMDiagram
     end
 
     def events
-      @aasm_instance.events.first.state_machine.events.values
+      @aasm_instance.events
     end
   end
 end

--- a/lib/aasm_diagram/tasks/generate.rake
+++ b/lib/aasm_diagram/tasks/generate.rake
@@ -7,13 +7,11 @@ namespace :'aasm-diagram' do
 
     smn = args[:smn]&.to_sym
 
-    model_instance = model_klass.new
-
     output_dir = ENV.fetch('AASM_DIAGRAM_OUTPUT_DIR') { './tmp' }
     output = File.join([output_dir, "#{args[:model]}-#{args[:smn] || 'default'}.png"])
 
     AASMDiagram::Diagram.new(
-      smn && model_instance.aasm(smn) || model_instance.aasm,
+      smn && model_klass.aasm(smn) || model_klass.aasm,
       output
     )
   end


### PR DESCRIPTION
Fixes #11 

Caveat: The way it gets called changes with this, instead of creating an instance of the class with the state machine, call diagram on the class state machine instead.